### PR TITLE
Add server-side Supabase helper and dependency

### DIFF
--- a/PsyCheck - App/middleware.ts
+++ b/PsyCheck - App/middleware.ts
@@ -1,3 +1,4 @@
+// Refresh session with Supabase SSR client
 
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'

--- a/PsyCheck - App/package-lock.json
+++ b/PsyCheck - App/package-lock.json
@@ -31,6 +31,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.45.0",
         "@tanstack-query-firebase/react": "^1.0.5",
         "@tanstack/react-query": "^5.66.0",
@@ -4162,6 +4163,27 @@
         "@types/ws": "^8.18.1",
         "isows": "^1.0.7",
         "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+      "integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
+    "node_modules/@supabase/ssr/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@supabase/storage-js": {

--- a/PsyCheck - App/package.json
+++ b/PsyCheck - App/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.45.0",
     "@tanstack-query-firebase/react": "^1.0.5",
     "@tanstack/react-query": "^5.66.0",

--- a/PsyCheck - App/src/lib/supabase/server.ts
+++ b/PsyCheck - App/src/lib/supabase/server.ts
@@ -1,0 +1,17 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export function getServerSupabase() {
+  const store = cookies()
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => store.get(name)?.value,
+        set: (name, value, options) => store.set({ name, value, ...options }),
+        remove: (name, options) => store.set({ name, value: '', ...options }),
+      },
+    }
+  )
+}

--- a/PsyCheck - App/src/middleware.ts
+++ b/PsyCheck - App/src/middleware.ts
@@ -1,4 +1,4 @@
-
+// Refresh session with Supabase SSR client
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 


### PR DESCRIPTION
## Summary
- add Supabase SSR helper for server-side use
- ensure middleware refreshes session using same Supabase client
- install `@supabase/ssr`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890af7857848330b85c987a9bff4ead