### PR TITLE
feat: validate Supabase env vars

### DIFF
--- a/PsyCheck - App/src/config/supabase.ts
+++ b/PsyCheck - App/src/config/supabase.ts
@@ -1,15 +1,7 @@
-
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseEnv } from '../lib/supabase/env';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL");
-}
-if (!supabaseAnonKey) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY");
-}
+const { url: supabaseUrl, anonKey: supabaseAnonKey } = getSupabaseEnv();
 
 // Singleton client for consistent access
 let supabaseInstance: SupabaseClient | null = null;

--- a/PsyCheck - App/src/lib/supabase/env.ts
+++ b/PsyCheck - App/src/lib/supabase/env.ts
@@ -1,0 +1,13 @@
+export function getSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url) {
+    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (!anonKey) {
+    throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  }
+
+  return { url, anonKey };
+}

--- a/PsyCheck - App/src/lib/supabase/server.ts
+++ b/PsyCheck - App/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import { getSupabaseEnv } from './env';
 
 /**
  * Server-side Supabase client bound to Next.js App Router cookies.
@@ -11,9 +12,11 @@ export function getServerSupabase() {
   // `cookies()` is synchronous in the App Router
   const cookieStore = cookies();
 
+  const { url, anonKey } = getSupabaseEnv();
+
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    url,
+    anonKey,
     {
       cookies: {
         /** Read a cookie value (undefined if absent) */

--- a/PsyCheck - App/src/middleware.ts
+++ b/PsyCheck - App/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { getSupabaseEnv } from './lib/supabase/env';
 
 /**
  * Refreshes the Supabase session on every request.
@@ -12,9 +13,11 @@ export async function middleware(request: NextRequest) {
   // Create a single mutable response (you can still call .cookies.set / .delete on it later)
   const response = NextResponse.next();
 
+  const { url, anonKey } = getSupabaseEnv();
+
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    url,
+    anonKey,
     {
       cookies: {
         /** Read a cookie from the incoming request */


### PR DESCRIPTION
## Summary
- add shared helper to verify required Supabase env vars
- use helper to guard server-side and middleware Supabase clients
- reuse helper for Supabase config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint setup)
- `npm run typecheck` (fails: type errors)


------
https://chatgpt.com/codex/tasks/task_e_6890cecca3408330a67cc30f4179d192